### PR TITLE
Added support for multiple proxy servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,44 @@ client.login
 
 Optional parameters to ```Client.new``` are:
 
-| Parameter   | Values     | Purpose |
-| ----------- | ---------- | ------- |
-|ssl:         | true/false | Use SSL for the connection. Defaults to false.|
-|proxy:       | string     | The M&M API server. Defaults to the same as the server: parameter. |
-|port:        | integer    | The TCP port for the connection. Defaults to 80 or 443 if SSL is enabled. |
-|verify\_ssl:  | true/false | Whether to validate SSL certificates. Defaults to true.|
+| Parameter    | Values     | Purpose |
+| -----------  | ---------- | ------- |
+|endpoint:     | string     | The URI for the web service. Defaults to /_mmwebext/mmwebext.dll?Soap. |
 |open\_timeout:| integer    | Seconds to wait for the initial connection to time out. Defaults to 10.|
+|port:         | integer    | The TCP port for the connection. Defaults to 80 or 443 if SSL is enabled. |
+|proxy:        | string     | The M&M API server. Defaults to the same as the server: parameter. |
+|ssl:          | true/false | Use SSL for the connection. Defaults to false.|
+|verify\_ssl:  | true/false | Whether to validate SSL certificates. Defaults to true.|
 
+### Advanced Connection Setup
+
+The client can optionally take an array of servers for the ```proxy:```
+parameter. This allows you to have redundant API servers without a load
+balancer.
+
+This also allows you to handle the case where the web server is running
+on the same servers as the Central service in a cluster configuration.
+This is important, because in this architecture the web component
+connects to the local server instead of using the DNS round robin entry
+and if you pick the inactive server then you will receive an error about
+operations being disabled.
+
+```ruby
+# When you have multiple web servers that are not behind a load balancer.
+client = MmJsonClient::Client.new(proxy: ['my-ipam01.example.com',
+                                          'my-ipam02.example.com'],
+                                  server: 'ipam-cluster-name.example.com',
+                                  username: 'demo',
+                                  password: 'demo')
+
+# When you have the web role on the M&M central servers in a cluster and need
+# to make sure you can connect to a functioning one.
+client = MmJsonClient::Client.new(proxy: ['my-ipam01.example.com',
+                                          'my-ipam02.example.com'],
+                                  server: 'localhost',
+                                  username: 'demo',
+                                  password: 'demo')
+```
 
 ### Case Conversion
 
@@ -102,6 +132,8 @@ MmJsonClient::Enums::AuthenticationType.values
 ```
 
 ### Learning and Exploration
+
+There are some [examples](examples/) in this repository.
 
 Check out the SOAP API docs on your server. Although this gem is using the
 JSON-RPC API, the methods, types, enumerations and responses are the same.

--- a/fixtures/vcr_cassettes/MmJsonClient_GenericType/multiple_proxy_servers/connects_to_another_proxy_when_one_is_disabled.yml
+++ b/fixtures/vcr_cassettes/MmJsonClient_GenericType/multiple_proxy_servers/connects_to_another_proxy_when_one_is_disabled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://test-ipam.local/_mmwebext/mmwebext.dll?Soap
+    uri: http://test-ipam02.local/_mmwebext/mmwebext.dll?Soap
     body:
       encoding: UTF-8
       string: '{"jsonrpc":"2.0","method":"Login","params":{"loginName":"testuser","password":"testpass","server":"localhost"}}'
@@ -21,24 +21,23 @@ http_interactions:
       message: OK
     headers:
       Content-Length:
-      - '76'
+      - '209'
       Content-Type:
       - application/json; charset=utf-8
       Server:
       - Microsoft-IIS/8.5
-      X-Powered-By:
-      - ASP.NET
       Date:
-      - Mon, 11 Jul 2016 17:57:38 GMT
+      - Wed, 13 Jul 2016 18:28:45 GMT
     body:
       encoding: UTF-8
-      string: '{"jsonrpc": "2.0", "result": {"session":"4bnH7Tn73YMX5DgiP6oU"}, "id":
-        null}'
+      string: '{"jsonrpc": "2.0", "error": {"code": 1037, "message": "Incoming requests
+        have been disabled on this server. Please select a server that is in a mode
+        that accepts incoming requests and try again."}, "id": null}'
     http_version: 
-  recorded_at: Mon, 11 Jul 2016 17:57:41 GMT
+  recorded_at: Wed, 13 Jul 2016 18:28:28 GMT
 - request:
     method: post
-    uri: http://test-ipam.local/_mmwebext/mmwebext.dll?Soap
+    uri: http://test-ipam01.local/_mmwebext/mmwebext.dll?Soap
     body:
       encoding: UTF-8
       string: '{"jsonrpc":"2.0","method":"Login","params":{"loginName":"testuser","password":"testpass","server":"localhost"}}'
@@ -62,14 +61,12 @@ http_interactions:
       - application/json; charset=utf-8
       Server:
       - Microsoft-IIS/8.5
-      X-Powered-By:
-      - ASP.NET
       Date:
-      - Wed, 13 Jul 2016 13:05:19 GMT
+      - Wed, 13 Jul 2016 18:28:50 GMT
     body:
       encoding: UTF-8
-      string: '{"jsonrpc": "2.0", "result": {"session":"kTq5p3frEk8eb3mAjHMC"}, "id":
+      string: '{"jsonrpc": "2.0", "result": {"session":"RV7qXnC0fbZBNrgjIhQh"}, "id":
         null}'
     http_version: 
-  recorded_at: Wed, 13 Jul 2016 13:05:27 GMT
+  recorded_at: Wed, 13 Jul 2016 18:28:34 GMT
 recorded_with: VCR 3.0.3

--- a/lib/mm_json_client/exceptions.rb
+++ b/lib/mm_json_client/exceptions.rb
@@ -5,7 +5,7 @@ module MmJsonClient
     attr_reader :message
 
     def initialize(code, message)
-      @code = code
+      @code = code.to_i
       @message = message
     end
 
@@ -17,4 +17,7 @@ module MmJsonClient
       message
     end
   end
+
+  # Could not connect to the server for what could be a transient reason.
+  class ServerConnectionError < StandardError; end
 end

--- a/lib/mm_json_client/json_rpc_http/client.rb
+++ b/lib/mm_json_client/json_rpc_http/client.rb
@@ -6,10 +6,9 @@ module MmJsonClient
   module JsonRpcHttp
     # A helper client for doing JSON-RPC calls over http.
     class Client
-      def initialize(base_url, _endpoint, options = {})
+      def initialize(base_url, options = {})
         @http_client =
-          MmJsonClient::HttpClient::Client.new(base_url,
-                                               '/_mmwebext/mmwebext.dll?Soap',
+          MmJsonClient::HttpClient::Client.new(base_url, options[:endpoint],
                                                allowed_client_options(options))
       end
 

--- a/lib/mm_json_client/response_code.rb
+++ b/lib/mm_json_client/response_code.rb
@@ -1,0 +1,6 @@
+module MmJsonClient
+  module ResponseCode
+    REQUESTS_DISABLED = 1037
+    INVALID_LOGIN = 16394
+  end
+end

--- a/spec/lib/mm_json_client/client_spec.rb
+++ b/spec/lib/mm_json_client/client_spec.rb
@@ -138,4 +138,26 @@ describe MmJsonClient::GenericType do
       expect(client.login).to eq(true)
     end
   end
+
+  describe 'multiple proxy servers', :vcr do
+    it 'connects to another proxy when one is disabled' do
+      client = MmJsonClient::Client.new(proxy: ['test-ipam02.local',
+                                                'test-ipam01.local'],
+                                        server: 'localhost',
+                                        username: 'testuser',
+                                        password: 'testpass')
+
+      expect(client.login).to eq(true)
+    end
+
+    # TODO: VCR isn't recording connection failures. Need to investigate.
+    # it 'connects to another proxy when the connection to one times out' do
+      # client = MmJsonClient::Client.new(proxy: ['172.16.56.100',
+      #                                           'test-ipam01.local'],
+      #                                   server: 'localhost',
+      #                                   username: 'testuser',
+      #                                   password: 'testpass')
+
+      # expect(client.login).to eq(true)
+  end
 end


### PR DESCRIPTION
The proxy: parameter to the client now optionally takes an array
of strings, or a single string as before, to handle a consolidated
architecture where the web server role is running on the M&M Central
servers that are also configured for HA via M&M clustering or where multiple
web servers are installed but not behind a load balancer.
